### PR TITLE
fix(security): path traversals

### DIFF
--- a/seashell/core/app.py
+++ b/seashell/core/app.py
@@ -32,6 +32,16 @@ from alive_progress import alive_bar
 from seashell.lib.config import Config
 
 
+def _sanitize_app_name(name: str) -> str:
+    safe = os.path.basename(name)
+    if os.path.altsep:
+        safe = safe.replace(os.path.altsep, '')
+    safe = safe.replace(os.path.sep, '')
+    if safe in ('', '.', '..'):
+        return ''
+    return safe
+
+
 class App(Config):
     """ Subclass of seashell.core module.
 
@@ -64,7 +74,9 @@ class App(Config):
         """
 
         if name:
-            self.app_name = name.lower().title()
+            safe = _sanitize_app_name(name)
+            if safe:
+                self.app_name = safe.lower().title()
 
         if bundle_id:
             self.bundle_id = bundle_id

--- a/seashell/modules/apple_ios/hook.py
+++ b/seashell/modules/apple_ios/hook.py
@@ -92,6 +92,9 @@ class ExternalCommand(Command):
         hook.patch_plist(self.plist)
 
         executable = hook.get_executable(self.plist)
+        if not executable:
+            self.print_error("Invalid executable path in Info.plist!")
+            return
         self.print_information(F"Executable to replace: {executable}")
 
         if not self.session.upload(self.plist, path + '/Info.plist'):

--- a/seashell/modules/apple_ios/photos.py
+++ b/seashell/modules/apple_ios/photos.py
@@ -48,16 +48,28 @@ class ExternalCommand(Command, String):
 
                 file_type = self.mode_type(hash.get('st_mode', 0))
                 path = file.get_string(TLV_TYPE_PATH)
+                name = os.path.split(path)[1]
+                if not self._safe_component(name):
+                    file = result.get_tlv(TLV_TYPE_GROUP)
+                    continue
 
                 if file_type == 'file':
                     self.session.download(
-                        path, local_path + '/' + os.path.split(path)[1])
+                        path, local_path + '/' + name)
 
                 elif file_type == 'directory':
                     self.recursive_walk(
-                        path, local_path + '/' + os.path.split(path)[1])
+                        path, local_path + '/' + name)
 
                 file = result.get_tlv(TLV_TYPE_GROUP)
+
+    @staticmethod
+    def _safe_component(name):
+        if not name or name in ('.', '..'):
+            return False
+        if os.path.sep in name or (os.path.altsep and os.path.altsep in name):
+            return False
+        return True
 
     def run(self, args):
         if args[1] == 'icloud':

--- a/seashell/modules/apple_ios/unhook.py
+++ b/seashell/modules/apple_ios/unhook.py
@@ -91,6 +91,9 @@ class ExternalCommand(Command):
         hook.patch_plist(self.plist, revert=True)
 
         executable = hook.get_executable(self.plist)
+        if not executable:
+            self.print_error("Invalid executable path in Info.plist!")
+            return
 
         if not self.session.upload(self.plist, path + '/Info.plist'):
             self.print_error("Failed to upload Info.plist!")


### PR DESCRIPTION
# Description

Fixes several path traversals that give arbitrary read/write to an attacker when handling a crafted `.ipa`, or in some cases a hostile iPhone. For example, during patching, a malicious `.ipa` could copy any file into its packed archive due to the use of `CFBundleExecutable` from the archive's `Info.plist` without proper sanitization in building paths.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Please correct if needed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
